### PR TITLE
Enhancement: Use ergebnis/classy instead of localheinz/classy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^7.2",
-    "localheinz/classy": "0.3.0"
+    "ergebnis/classy": "~0.5.0"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,35 +4,43 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ec0180ef2db717da1c6b7ce2c6099dc",
+    "content-hash": "aca21df2b340cb40907c7ae788ca46ee",
     "packages": [
         {
-            "name": "localheinz/classy",
-            "version": "0.3.0",
+            "name": "ergebnis/classy",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/localheinz/classy.git",
-                "reference": "8f1413f01a464f88521eac735f0e62b02da9ac67"
+                "url": "https://github.com/ergebnis/classy.git",
+                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/classy/zipball/8f1413f01a464f88521eac735f0e62b02da9ac67",
-                "reference": "8f1413f01a464f88521eac735f0e62b02da9ac67",
+                "url": "https://api.github.com/repos/ergebnis/classy/zipball/7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
+                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "ext-tokenizer": "*",
+                "php": "^7.2"
             },
             "require-dev": {
-                "localheinz/php-cs-fixer-config": "~1.6.2",
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "infection/infection": "~0.15.0",
+                "localheinz/composer-normalize": "^1.3.1",
+                "localheinz/phpstan-rules": "~0.13.0",
                 "localheinz/test-util": "0.2.2",
-                "phpbench/phpbench": "0.13.0",
-                "phpunit/phpunit": "^6.4.1"
+                "phpbench/phpbench": "~0.16.10",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.4.3",
+                "zendframework/zend-file": "^2.8.3"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Localheinz\\Classy\\": "src/"
+                    "Ergebnis\\Classy\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -46,8 +54,8 @@
                 }
             ],
             "description": "Provides a way to collect classy constructs from source or a directory.",
-            "abandoned": "ergebnis/classy",
-            "time": "2017-10-24T14:31:40+00:00"
+            "homepage": "https://github.com/ergebnis/classy",
+            "time": "2019-12-05T22:45:51+00:00"
         }
     ],
     "packages-dev": [
@@ -342,57 +350,6 @@
                 "php"
             ],
             "time": "2019-10-30T14:39:59+00:00"
-        },
-        {
-            "name": "ergebnis/classy",
-            "version": "0.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ergebnis/classy.git",
-                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/classy/zipball/7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
-                "reference": "7ba774c203fd1e9b6ab5aad846b500a3d9121fd9",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.2"
-            },
-            "require-dev": {
-                "ergebnis/php-cs-fixer-config": "~1.1.0",
-                "infection/infection": "~0.15.0",
-                "localheinz/composer-normalize": "^1.3.1",
-                "localheinz/phpstan-rules": "~0.13.0",
-                "localheinz/test-util": "0.2.2",
-                "phpbench/phpbench": "~0.16.10",
-                "phpstan/phpstan": "~0.11.19",
-                "phpstan/phpstan-deprecation-rules": "~0.11.2",
-                "phpstan/phpstan-strict-rules": "~0.11.1",
-                "phpunit/phpunit": "^8.4.3",
-                "zendframework/zend-file": "^2.8.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ergebnis\\Classy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a way to collect classy constructs from source or a directory.",
-            "homepage": "https://github.com/ergebnis/classy",
-            "time": "2019-12-05T22:45:51+00:00"
         },
         {
             "name": "ergebnis/php-cs-fixer-config",

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\FactoryMuffin\Definition;
 
+use Ergebnis\Classy;
 use League\FactoryMuffin\FactoryMuffin;
-use Localheinz\Classy;
 
 final class Definitions
 {


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/classy` instead of `localheinz/classy`